### PR TITLE
Image download and deletion implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,4 +44,5 @@ dependencies {
     implementation(libs.firebase.firestore)
     implementation(libs.firebase.storage)
     implementation(libs.firebase.auth)
+    implementation(libs.glide)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.PickMe"
         tools:targetApi="31">
+        <activity android:name=".views.Example_ImageUpload" />
         <activity
             android:name=".views.MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/pickme/models/Image.java
+++ b/app/src/main/java/com/example/pickme/models/Image.java
@@ -98,6 +98,7 @@ public class Image {
         temp.put("createdAt", getCreatedAt());
         temp.put("imageType", getType());
         temp.put("imageUrl", getImageUrl());
+        temp.put("imageAssociation", getImageAssociation());
         temp.put("uploaderId", getUploaderId());
 
         return temp;

--- a/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
+++ b/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
@@ -197,6 +197,89 @@ public class ImageRepository {
         download(u, null, callback);
     }
 
-    public void delete() {
+
+    /**
+     * Delete an event poster from Firestore db.
+     * @param u The user matching to uploaderId
+     * @param e The event matching to imageAssociation
+     */
+    public void delete(@NotNull User u, Event e) {
+        if (e == null) {
+            Query profileImg = imgCollection
+                    .where(Filter.and(
+                            Filter.equalTo("imageType", "PROFILE_PICTURE"),
+                            Filter.equalTo("uploaderId", u.getUserId()),
+                            Filter.equalTo("imageAssociation", u.getUserId())));
+
+            profileImg.get()
+                    .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                        @Override
+                        public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                            if (task.isSuccessful()) {
+                                QuerySnapshot queryRes = task.getResult();
+                                if (!queryRes.isEmpty()) {
+                                    DocumentReference doc = queryRes
+                                            .getDocuments()
+                                            .get(0)
+                                            .getReference();
+                                    Log.d(TAG, "DB: Query successful, deleting document " + doc.getId());
+                                    doc.delete()
+                                            .addOnCompleteListener(new OnCompleteListener<Void>() {
+                                                @Override
+                                                public void onComplete(@NonNull Task<Void> task) {
+                                                    if (task.isSuccessful()) {
+                                                        Log.d(TAG, "DB: Deletion successful");
+                                                    }
+                                                }
+                                            });
+                                } else {
+                                    Log.d(TAG, "DB: Query returned empty, no deletion occurred");
+                                }
+                            }
+                        }
+                    });
+        } else {
+            Query eventPoster = imgCollection
+                    .where(Filter.and(
+                            Filter.equalTo("imageType", "EVENT_POSTER"),
+                            Filter.equalTo("uploaderId", u.getUserId()),
+                            Filter.equalTo("imageAssociation", e.getEventId())));
+
+            eventPoster
+                    .get()
+                    .addOnCompleteListener(new OnCompleteListener<QuerySnapshot>() {
+                        @Override
+                        public void onComplete(@NonNull Task<QuerySnapshot> task) {
+                            QuerySnapshot queryRes = task.getResult();
+                            if (!queryRes.isEmpty()) {
+                                DocumentReference doc = queryRes
+                                        .getDocuments()
+                                        .get(0)
+                                        .getReference();
+                                Log.d(TAG, "DB: Query successful, deleting document " + doc.getId());
+                                doc.delete()
+                                        .addOnCompleteListener(new OnCompleteListener<Void>() {
+                                            @Override
+                                            public void onComplete(@NonNull Task<Void> task) {
+                                                if (task.isSuccessful()) {
+                                                    Log.d(TAG, "DB: Deletion successful");
+                                                }
+                                            }
+                                        });
+                            } else {
+                                Log.d(TAG, "DB: Query returned empty, no deletion occurred");
+                            }
+                        }
+                    });
+        }
     }
+
+    /**
+     * Delete a profile picture from Firestore db.
+     * @param u The user matching to uploaderId and imageAssociation
+     */
+    public void delete(@NotNull User u) {
+        delete(u, null);
+    }
+
 }

--- a/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
+++ b/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
@@ -114,6 +114,16 @@ public class ImageRepository {
     }
 
     public void download() {
+    /**
+     * Callback interface required for accessing asynchronous query data. <br>
+     * <i>onQuerySuccess(String imageUrl)</i> to access the imageUrl <br>
+     * <i>onQueryEmpty()</i> to handle empty queries
+     */
+    public interface queryCallback {
+        void onQuerySuccess(String imageUrl);
+        void onQueryEmpty();
+    }
+
     }
 
     public void delete() {

--- a/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
+++ b/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
@@ -3,14 +3,21 @@ package com.example.pickme.repositories;
 import android.net.Uri;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.example.pickme.models.Enums.ImageType;
 import com.example.pickme.models.Event;
 import com.example.pickme.models.Image;
 import com.example.pickme.models.User;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.Filter;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QuerySnapshot;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
 
@@ -19,7 +26,8 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Handles interactions with the images collection
  * @author sophiecabungcal
- * @version 1.0
+ * @author etdong
+ * @version 1.1
  * Responsibilities:
  * CRUD operations for image data
  */

--- a/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
+++ b/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.NotNull;
  * CRUD operations for image data
  */
 public class ImageRepository {
+    private final String TAG = "ImageRepository";
     // image storage
     private final FirebaseStorage storage = FirebaseStorage.getInstance();
     private final StorageReference imgStorage = storage.getReference();

--- a/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
+++ b/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
@@ -10,6 +10,7 @@ import com.example.pickme.models.Event;
 import com.example.pickme.models.Image;
 import com.example.pickme.models.User;
 import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.android.gms.tasks.Task;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.CollectionReference;
@@ -222,14 +223,21 @@ public class ImageRepository {
                                             .getDocuments()
                                             .get(0)
                                             .getReference();
-                                    Log.d(TAG, "DB: Query successful, deleting document " + doc.getId());
+                                    String imageId = doc.getId();
+                                    Log.d(TAG, "DB: Query successful");
+                                    Log.d(TAG, "STORAGE: Deleting file " + imageId);
+                                    imgStorage.child(imageId).delete().addOnSuccessListener(new OnSuccessListener<Void>() {
+                                        @Override
+                                        public void onSuccess(Void unused) {
+                                            Log.d(TAG, "STORAGE: File " + imageId + " deleted");
+                                        }
+                                    });
+                                    Log.d(TAG, "DB: Deleting document " + imageId);
                                     doc.delete()
-                                            .addOnCompleteListener(new OnCompleteListener<Void>() {
+                                            .addOnSuccessListener(new OnSuccessListener<Void>() {
                                                 @Override
-                                                public void onComplete(@NonNull Task<Void> task) {
-                                                    if (task.isSuccessful()) {
-                                                        Log.d(TAG, "DB: Deletion successful");
-                                                    }
+                                                public void onSuccess(Void unused) {
+                                                    Log.d(TAG, "DB: Document " + imageId + " deleted");
                                                 }
                                             });
                                 } else {
@@ -256,14 +264,21 @@ public class ImageRepository {
                                         .getDocuments()
                                         .get(0)
                                         .getReference();
-                                Log.d(TAG, "DB: Query successful, deleting document " + doc.getId());
+                                String imageId = doc.getId();
+                                Log.d(TAG, "DB: Query successful");
+                                Log.d(TAG, "STORAGE: Deleting file " + imageId);
+                                imgStorage.child(imageId).delete().addOnSuccessListener(new OnSuccessListener<Void>() {
+                                    @Override
+                                    public void onSuccess(Void unused) {
+                                        Log.d(TAG, "STORAGE: File " + imageId + " deleted");
+                                    }
+                                });
+                                Log.d(TAG, "DB: Deleting document " + imageId);
                                 doc.delete()
-                                        .addOnCompleteListener(new OnCompleteListener<Void>() {
+                                        .addOnSuccessListener(new OnSuccessListener<Void>() {
                                             @Override
-                                            public void onComplete(@NonNull Task<Void> task) {
-                                                if (task.isSuccessful()) {
-                                                    Log.d(TAG, "DB: Deletion successful");
-                                                }
+                                            public void onSuccess(Void unused) {
+                                                Log.d(TAG, "DB: Document " + imageId + " deleted");
                                             }
                                         });
                             } else {

--- a/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
+++ b/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
@@ -46,7 +46,7 @@ public class ImageRepository {
         FirebaseAuth auth = FirebaseAuth.getInstance();
         auth.signInAnonymously().addOnCompleteListener(task -> {
             if (task.isSuccessful()) {
-                Log.d("ImageRepository", "AUTH: Successful authentication");
+                Log.d(TAG, "AUTH: Successful authentication");
             }
         });
     }
@@ -55,11 +55,12 @@ public class ImageRepository {
     /**
      * Uploads an event poster URI to FirebaseStorage,
      * then stores the image information to Firestore DB.
+     *
+     * @param u      The user object (uploader)
+     * @param e      The event object (event poster)
      * @param imgUri The image URI to upload (e.g. one obtained from an image picker)
-     * @param u The user object (uploader)
-     * @param e The event object (event poster)
      */
-    public void upload(@NotNull Uri imgUri, @NotNull User u, Event e) {
+    public void upload(@NotNull User u, Event e, @NotNull Uri imgUri) {
         // creating document first to generate unique id
         DocumentReference imgDoc = imgCollection.document();
 
@@ -70,7 +71,7 @@ public class ImageRepository {
         imgRef
             .putFile(imgUri)
             .addOnSuccessListener(taskSnapshot -> {
-                Log.d("ImageRepository", "STORAGE: URI " + imgUri + " upload successful");
+                Log.d(TAG, "STORAGE: URI " + imgUri + " upload successful");
 
                 // now get the image download url...
                 imgRef.getDownloadUrl().addOnSuccessListener(uri -> {
@@ -96,7 +97,7 @@ public class ImageRepository {
                     imgDoc
                         .set(img.getUploadPackage())
                         .addOnSuccessListener(unused ->
-                                Log.d("ImageRepository","DB: Upload successful"));
+                                Log.d(TAG,"DB: Upload successful"));
                 });
             });
     }
@@ -104,11 +105,12 @@ public class ImageRepository {
     /**
      * Uploads a profile image URI to FirebaseStorage,
      * then stores the image information to Firestore DB.
+     *
+     * @param u      The user object (uploader/subject)
      * @param imgUri The image URI to upload (e.g. one obtained from an image picker)
-     * @param u The user object (uploader/subject)
      */
-    public void upload(Uri imgUri, User u) {
-        upload(imgUri, u, null);
+    public void upload(@NotNull User u, @NotNull Uri imgUri) {
+        upload(u, null, imgUri);
     }
 
     public void download() {

--- a/app/src/main/java/com/example/pickme/views/Example_ImageUpload.java
+++ b/app/src/main/java/com/example/pickme/views/Example_ImageUpload.java
@@ -2,8 +2,9 @@ package com.example.pickme.views;
 
 import android.os.Bundle;
 import android.util.Log;
-import android.view.View;
 import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.Toast;
 
 import androidx.activity.EdgeToEdge;
 import androidx.activity.result.ActivityResultLauncher;
@@ -11,6 +12,7 @@ import androidx.activity.result.PickVisualMediaRequest;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.bumptech.glide.Glide;
 import com.example.pickme.R;
 import com.example.pickme.models.Event;
 import com.example.pickme.models.User;
@@ -19,23 +21,78 @@ import com.google.firebase.firestore.FirebaseFirestore;
 
 public class Example_ImageUpload extends AppCompatActivity {
 
+    //region Attributes
+
+    String TAG = "Example_ImageUpload";
     private FirebaseFirestore db;
 
     User user1 = new User();
     Event event1 = new Event();
+    //endregion
 
-    // this is the gallery picker promise/contract so we can grab the image uri
-    ActivityResultLauncher<PickVisualMediaRequest> pickMedia =
+    //region Activity result contracts
+
+    // these are the gallery picker promises/contracts so we can grab the image uri
+
+    ActivityResultLauncher<PickVisualMediaRequest> pickPfp =
             registerForActivityResult(new ActivityResultContracts.PickVisualMedia(), uri -> {
                 // callback is invoked after the user selects a media item or closes the photo picker
                 if (uri != null) {
                     ImageRepository ir = new ImageRepository();
-                    ir.upload(uri, user1);
-                    ir.upload(uri, user1, event1);
+                    ir.download(user1, new ImageRepository.queryCallback() {
+                        @Override
+                        public void onQuerySuccess(String imageUrl) {
+                            // if an image of this type already exists, remove it
+                            ir.delete(user1);
+                        }
+
+                        @Override
+                        public void onQueryEmpty() {
+                        }
+                    });
+                    ir.upload(user1, uri);
+                    Toast.makeText(
+                            Example_ImageUpload.this,
+                            "Profile picture uploaded for user: " + user1.getUserId(),
+                            Toast.LENGTH_SHORT).show();
                 } else {
-                    Log.d("PhotoPicker", "No media selected");
+                    Toast.makeText(
+                            Example_ImageUpload.this,
+                            "No media selected",
+                            Toast.LENGTH_SHORT).show();
                 }
             });
+
+    ActivityResultLauncher<PickVisualMediaRequest> pickEP =
+            registerForActivityResult(new ActivityResultContracts.PickVisualMedia(), uri -> {
+                // callback is invoked after the user selects a media item or closes the photo picker
+                if (uri != null) {
+                    ImageRepository ir = new ImageRepository();
+                    ir.download(user1, event1, new ImageRepository.queryCallback() {
+                        @Override
+                        public void onQuerySuccess(String imageUrl) {
+                            ir.delete(user1, event1);
+                        }
+
+                        @Override
+                        public void onQueryEmpty() {
+                        }
+                    });
+                    ir.upload(user1, event1, uri);
+                    Toast.makeText(
+                            Example_ImageUpload.this,
+                            "Event poster uploaded for event: " + event1.getEventId(),
+                            Toast.LENGTH_SHORT).show();
+                } else {
+                    Log.d("PhotoPicker", "No media selected");
+                    Toast.makeText(
+                            Example_ImageUpload.this,
+                            "No media selected",
+                            Toast.LENGTH_SHORT).show();
+                }
+            });
+
+    //endregion
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -43,15 +100,95 @@ public class Example_ImageUpload extends AppCompatActivity {
         EdgeToEdge.enable(this);
         setContentView(R.layout.imageupload_example);
 
-        Button uploadButton = findViewById(R.id.button) ;
-        uploadButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                // launch the picker to complete the promise (limited to single image)
-                pickMedia.launch(new PickVisualMediaRequest.Builder()
-                        .setMediaType(ActivityResultContracts.PickVisualMedia.ImageOnly.INSTANCE)
-                        .build());
-            }
+        user1.setUserId("1234_user_test");
+        event1.setEventId("1234_event_test");
+
+        // uploads
+        Button uploadPfpButton = findViewById(R.id.uploadPfpButton) ;
+        uploadPfpButton.setOnClickListener(view -> {
+            // launch the picker to complete the promise (limited to single image)
+            pickPfp.launch(new PickVisualMediaRequest.Builder()
+                    .setMediaType(ActivityResultContracts.PickVisualMedia.ImageOnly.INSTANCE)
+                    .build());
         });
+
+        Button uploadEPButton = findViewById(R.id.uploadEPButton) ;
+        uploadEPButton.setOnClickListener(view -> {
+            pickEP.launch(new PickVisualMediaRequest.Builder()
+                    .setMediaType(ActivityResultContracts.PickVisualMedia.ImageOnly.INSTANCE)
+                    .build());
+        });
+
+        // downloads
+        ImageView imageView = findViewById(R.id.imageView);
+
+        Button downloadPfpButton = findViewById(R.id.downloadPfpButton);
+        downloadPfpButton.setOnClickListener(view -> {
+            ImageRepository ir = new ImageRepository();
+
+            // clears the imageview
+            imageView.setImageResource(0);
+
+            // download method requires a callback to access asynchronous query data
+            ir.download(user1, new ImageRepository.queryCallback() {
+                @Override
+                public void onQuerySuccess(String imageUrl) {
+                    // using glide to show image on imageView; subject to change
+                    Glide.with(view)
+                            .load(imageUrl)
+                            .into(imageView);
+                }
+
+                @Override
+                public void onQueryEmpty() {
+                    // show a toast when the query is empty
+                    Toast.makeText(
+                            Example_ImageUpload.this,
+                            "Cannot find profile picture for user: " + user1.getUserId(),
+                            Toast.LENGTH_SHORT).show();
+                }
+            });
+        });
+
+        Button downloadEPButton = findViewById(R.id.downloadEPButton);
+        downloadEPButton.setOnClickListener(view -> {
+            ImageRepository ir = new ImageRepository();
+
+            // clears the imageview
+            imageView.setImageResource(0);
+
+            ir.download(user1, event1, new ImageRepository.queryCallback() {
+                @Override
+                public void onQuerySuccess(String imageUrl) {
+                    Glide.with(view)
+                            .load(imageUrl)
+                            .into(imageView);
+                }
+
+                @Override
+                public void onQueryEmpty() {
+                    Toast.makeText(
+                            Example_ImageUpload.this,
+                            "Cannot find event poster for event: " + event1.getEventId(),
+                            Toast.LENGTH_SHORT).show();
+                }
+            });
+        });
+
+        // deletes
+        Button deletePfpButton = findViewById(R.id.deletePfpButton);
+        deletePfpButton.setOnClickListener(view -> {
+            ImageRepository ir = new ImageRepository();
+            // deletion also checks for empty query but just logs to Logcat instead of toasting
+            ir.delete(user1);
+        });
+
+        Button deleteEPButton = findViewById(R.id.deleteEPButton);
+        deleteEPButton.setOnClickListener(view -> {
+            ImageRepository ir = new ImageRepository();
+            ir.delete(user1, event1);
+        });
+
+
     }
 }

--- a/app/src/main/res/layout/imageupload_example.xml
+++ b/app/src/main/res/layout/imageupload_example.xml
@@ -5,11 +5,79 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <Button
-        android:id="@+id/button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Button"
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="300dp"
+        android:layout_height="300dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <LinearLayout
+        android:id="@+id/linearLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        app:layout_constraintTop_toBottomOf="@+id/imageView">
+
+        <Button
+            android:id="@+id/uploadPfpButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Upload PFP"
+            android:layout_margin="10dp"/>
+
+        <Button
+            android:id="@+id/uploadEPButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Upload EP"
+            android:layout_margin="10dp"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/linearLayout2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout">
+
+        <Button
+            android:id="@+id/downloadPfpButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="Download PFP" />
+
+        <Button
+            android:id="@+id/downloadEPButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="Download EP" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        app:layout_constraintTop_toBottomOf="@+id/linearLayout2">
+
+        <Button
+            android:id="@+id/deletePfpButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="Delete PFP" />
+
+        <Button
+            android:id="@+id/deleteEPButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="Delete EP" />
+    </LinearLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 agp = "8.7.1"
 firebaseBom = "33.5.0"
+glide = "4.16.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
@@ -14,6 +15,7 @@ firebaseStorage = "21.0.1"
 [libraries]
 firebase-auth = { module = "com.google.firebase:firebase-auth" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
## Downloading and deleting images has now been implemented
Of course let me know if there's any issues with the methods or improvements to be made. Thanks!
<details><summary><h3>Download method summary</h3></summary>
<p>
<b>Forms</b><br>
download(User u, Event e, queryCallback callback) <br>
download(User u, queryCallback callback)

The tricky part of this was working around the concurrency issues with the async Firebase calls. Needing to override success/completion listeners to grab our data (the image URL) at the right time meant that returning that data back to the enclosing method was not possible by default.

A common solution to this is just using a callback, which I implemented the interface **queryCallback** for. It has two overloads, one for a successful query _onQuerySuccess(String imageUrl)_ which allows access to the returned image url, and one for an query that turns up empty _onQueryEmpty()_ so we are able to handle that case (probably display an error or something to the user).

The query itself basically checks for uploaderId, imageAssociation, and imageType.
When download is called with only a user passed to it, that means there is no event associated to the image, therefore it is a profile picture. It then checks for:
imageType == "PROFILE_PICTURE" AND uploaderId == imageAssociation == user.getUserId()
When an event is passed, it checks:
imageType == "EVENT_POSTER" AND uploaderId == user.getUserId() AND imageAssociation == event.getEventId()
</p>
</details> 

<details><summary><h3>Delete method summary</h3></summary>
<p>
<b>Forms</b> <br>
delete(User u, Events e) <br>
delete(User u)

The naming of the method is subject to change, but considering it will always be called with an  <i>ImageRepository</i> object, surely the deletion ambiguity is squashed.

We are doing pretty much the same query as the download method but just deleting the document on successful query. Otherwise, just log that no deletion occurred. We don't need the callback here since we are not accessing any queried data.
</p>
</details> 
<br>
<h3>Notes</h3>

- **_What if we have two separate documents with the same queried attributes? (imageType, uploaderId, imageAssociation)_** 
Obviously if somebody uploads two profile pictures, this will happen. We might have to handle this differently but in the Example_ImageUpload activity, I just queried for an image when we tried an upload and deleted the image from db if it existed already. Not sure how good this is performance wise but we should talk about this case.

- Again, this code is quite ugly -- lots of nesting and broken up statements. If there's any style rules that we can gather from this that would be great for the future. This is basically just default Android Studio auto-formatting.
- I used Glide to put the image URLs into an ImageView. Seemed like the easiest way to do it, but if you got another suggestion then let me know.
- The download queries are primitive. Maybe there's a better way to grab the right image?
- There are a lot of warnings about switching the anonymous functions + overloads to lambdas and unnecessary explicit type arguments. I like the descriptiveness of the anonymous functions + overloads and type arguments, so I reverted the ones I had already changed to lambdas. What should the standard be?
- I personally think it's nice to have log output everywhere for dev purposes and Logcat is not terrible to look at either so I just put a bunch of log.d in places that y'all might want to see.
