### PR TITLE
more organized image storage locations

### DIFF
--- a/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
+++ b/app/src/main/java/com/example/pickme/repositories/ImageRepository.java
@@ -175,7 +175,8 @@ public class ImageRepository {
 
         String imageId = doc.getId();
         String uploaderId = i.getUploaderId();
-        StorageReference imgRef = imgStorage.child(uploaderId).child(imageId);
+        String imageType = i.getImageType().toString();
+        StorageReference imgRef = imgStorage.child(imageType).child(uploaderId).child(imageId);
 
         // update storage file
         imgRef
@@ -204,7 +205,8 @@ public class ImageRepository {
 
         String imageId = doc.getId();
         String uploaderId = i.getUploaderId();
-        StorageReference imgRef = imgStorage.child(uploaderId).child(imageId);
+        String imageType = i.getImageType().toString();
+        StorageReference imgRef = imgStorage.child(imageType).child(uploaderId).child(imageId);
 
         // update storage file
         imgRef
@@ -299,6 +301,7 @@ public class ImageRepository {
                             Log.d(TAG, "delete: Query successful");
                             Log.d(TAG, String.format("delete: Deleting file %s", imageId));
                             imgStorage
+                                    .child(imageType)
                                     .child(uploaderId)
                                     .child(imageId)
                                     .delete()


### PR DESCRIPTION
moved images into their own respective image_type folder in firebase storage. old images were not deleted for the sake of not breaking anything